### PR TITLE
Fix typo in Starter module

### DIFF
--- a/PoliMi-Computer-Graphics-/A02/include/modules/Starter.hpp
+++ b/PoliMi-Computer-Graphics-/A02/include/modules/Starter.hpp
@@ -141,7 +141,7 @@ ErrorCodes[ ] = {
 	{ VK_SUBOPTIMAL_KHR, "Suboptimal" },
 	{ VK_ERROR_OUT_OF_DATE_KHR, "Error Out of Date" },
 	{ VK_ERROR_INCOMPATIBLE_DISPLAY_KHR, "Incompatible Display" },
-	{ VK_ERROR_VALIDATION_FAILED_EXT, "Valuidation Failed" },
+        { VK_ERROR_VALIDATION_FAILED_EXT, "Validation Failed" },
 	{ VK_ERROR_INVALID_SHADER_NV, "Invalid Shader" },
 	{ VK_ERROR_OUT_OF_POOL_MEMORY_KHR, "Out of Pool Memory" },
 	{ VK_ERROR_INVALID_EXTERNAL_HANDLE, "Invalid External Handle" },


### PR DESCRIPTION
## Summary
- correct a typo in an error string constant

## Testing
- `grep -R "Valuidation" -n --exclude-dir=cmake-build* || true`

------
https://chatgpt.com/codex/tasks/task_e_687e4835758883259f4d15e55e463641