### PR TITLE
Fix texture allocation in Scene

### DIFF
--- a/PoliMi-Computer-Graphics-/A02/include/modules/Scene.hpp
+++ b/PoliMi-Computer-Graphics-/A02/include/modules/Scene.hpp
@@ -65,7 +65,7 @@ class Scene {
 			TextureCount = ts.size();
 			std::cout << "Textures count: " << TextureCount << "\n";
 
-			T = (Texture **)calloc(ModelCount, sizeof(Texture *));
+                        T = (Texture **)calloc(TextureCount, sizeof(Texture *));
 			for(int k = 0; k < TextureCount; k++) {
 				TextureIds[ts[k]["id"]] = k;
 				T[k] = new Texture();


### PR DESCRIPTION
## Summary
- ensure texture array uses `TextureCount` for allocation

## Testing
- `cmake ..` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_687e491b80c4832596bbfe36d3e755ea